### PR TITLE
Allow comments in tsconfig and show user error message if load fails

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
       "request": "launch",
       "name": "Example adapter",
       "runtimeExecutable": "${execPath}",
+      "preLaunchTask": "tsc",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--traceResolution"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+			{
+				"label": "tsc",
+					"type": "typescript",
+					"tsconfig": "tsconfig.json",
+					"problemMatcher": [
+							"$tsc"
+					],
+					"group": {
+							"kind": "build",
+							"isDefault": true
+					}
+			}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Run your [TestyTs](https://www.npmjs.com/package/testyts) tests using the
 
 Property                        | Description
 --------------------------------|---------------------------------------------------------------
-`testyTsExplorer.debuggerPort`        | The port to use for debugging sessions (default: `9229`)
-`testyTsExplorer.nodePath`         | The path to the node executable to use. By default, it will attempt to find it on your PATH.
+`testyTsExplorer.debuggerPort`  | The port to use for debugging sessions (default: `9229`)
+`testyTsExplorer.nodePath`      | The path to the node executable to use. By default, it will attempt to find it on your PATH.
 
 
 ## Commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-testyts-test-adapter",
-    "version": "0.2.1",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-testyts-test-adapter",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2775,8 +2775,7 @@
         "typescript": {
             "version": "3.1.6",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-            "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
-            "dev": true
+            "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
         },
         "uc.micro": {
             "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1571,11 +1571,6 @@
                 "minimist": "^1.2.0"
             }
         },
-        "jsonc-parser": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
-            "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
-        },
         "jsonify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,14 @@
 {
     "name": "vscode-testyts-test-adapter",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@testy/assertion": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@testy/assertion/-/assertion-0.1.1.tgz",
+            "integrity": "sha512-MpqyVxOmUcvItLB09dAQ1+8Ex944eKa+kTDiPWsfA9ifld0tmjdIKOO6+3C1MykdXnno4jywS+K8w62YsqukNQ=="
+        },
         "@types/json5": {
             "version": "0.0.29",
             "resolved": "http://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -327,7 +332,8 @@
         "commander": {
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-            "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+            "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+            "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
@@ -780,6 +786,7 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -1563,6 +1570,11 @@
             "requires": {
                 "minimist": "^1.2.0"
             }
+        },
+        "jsonc-parser": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+            "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
         },
         "jsonify": {
             "version": "0.0.0",
@@ -2544,15 +2556,41 @@
             }
         },
         "testyts": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/testyts/-/testyts-0.7.1.tgz",
-            "integrity": "sha512-9GL24165xUksc7WsINEOriSI1P15RJ/H5wIN3GwC03nBlVOWHsDYEpmp1w4N1AhMq19MBeyrjOcYOo3kUzTlMw==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/testyts/-/testyts-1.0.1.tgz",
+            "integrity": "sha512-77L5itZ+Y/F1dK/rpXBFXaAtnmprO2RGV6qEoRGuqGJ0uMsHZ/DM/cU0MR84zGVdmw/3wsFZ94Ys7d6NOsQj3Q==",
             "requires": {
-                "commander": "^2.19.0",
-                "glob": "^7.1.3",
+                "@testy/assertion": "^0.1.1",
+                "commander": "^4.1.1",
+                "glob": "^7.1.6",
                 "reflect-metadata": "^0.1.12",
                 "ts-node": "^7.0.1",
-                "typescript": "^3.1.6"
+                "typescript": "^3.8.3"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+                    "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+                },
+                "glob": {
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "typescript": {
+                    "version": "3.9.3",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+                    "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ=="
+                }
             }
         },
         "through": {
@@ -2737,7 +2775,8 @@
         "typescript": {
             "version": "3.1.6",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-            "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+            "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+            "dev": true
         },
         "uc.micro": {
             "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
         "ts-node": "^7.0.1",
         "tsconfig-paths": "^3.7.0",
         "tslib": "^1.9.3",
+        "typescript": "^3.0.3",
         "vscode-test-adapter-api": "^1.0.1",
         "vscode-test-adapter-util": "^0.5.0"
     },
     "devDependencies": {
         "@types/paralleljs": "0.0.18",
-        "typescript": "^3.0.3",
         "vsce": "^1.47.0",
         "vscode": "^1.1.21"
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "publish": "vsce publish"
     },
     "dependencies": {
-        "jsonc-parser": "^2.2.1",
         "testyts": "^1.0.1",
         "ts-node": "^7.0.1",
         "tsconfig-paths": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "icon": "img/TestyTsTestExplorer.png",
     "author": "Antoine Boisier-Michaud <aboisiermichaud@gmail.com>",
     "publisher": "Testy",
-    "version": "0.2.0",
+    "version": "1.0.0",
     "license": "MIT",
     "homepage": "https://github.com/Testy/vscode-testyts-test-adapter",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "publish": "vsce publish"
     },
     "dependencies": {
-        "testyts": "0.7.x",
+        "jsonc-parser": "^2.2.1",
+        "testyts": "^1.0.1",
         "ts-node": "^7.0.1",
         "tsconfig-paths": "^3.7.0",
         "tslib": "^1.9.3",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -44,7 +44,7 @@ export class TestyTsAdapter implements TestAdapter {
             { cwd: this.workspace.uri.fsPath, execPath: this.config.nodePath, execArgv: [] })
             .on('message', (response: TestSuiteInfo) => {
                 if (response instanceof String || typeof response === "string") {
-                    vscode.window.showErrorMessage(response.toString());// Let the user know what is wrong (e.g. tsc failed)
+                    vscode.window.showErrorMessage(response.toString());
                     console.log(response);
                     this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: null });
                 }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -43,9 +43,10 @@ export class TestyTsAdapter implements TestAdapter {
         fork(require.resolve('./workers/testLoader.worker.js'), [],
             { cwd: this.workspace.uri.fsPath, execPath: this.config.nodePath, execArgv: [] })
             .on('message', (response: TestSuiteInfo) => {
-                if (response instanceof String) {
+                if (response instanceof String || typeof response === "string") {
+                    vscode.window.showErrorMessage(response.toString());// Let the user know what is wrong (e.g. tsc failed)
                     console.log(response);
-                    throw response;
+                    this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: null });
                 }
                 else {
                     this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: response });

--- a/src/workers/configLoader.ts
+++ b/src/workers/configLoader.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { TestyConfig } from 'testyts/build/lib/interfaces/config';
+import { readConfigFile } from 'typescript';
+
+export function loadTestyTsConfig(): TestyConfig {
+    return _readFile('testy.json');
+}
+
+export function loadTsConfig() {
+    return _readFile('tsconfig.json');    
+}
+
+function _readFile(relativePath: string) {
+    const absolutePath = resolve(process.cwd(), relativePath);
+    const response = readConfigFile(absolutePath, _readFileSync);
+    if (response == null || response.error != null) {
+        throw new Error(`An error occured while reading the file ${absolutePath}`);
+    }
+
+    return response.config;
+}
+
+function _readFileSync(path: string): string {
+    return readFileSync(path).toString();
+}

--- a/src/workers/testLoader.worker.ts
+++ b/src/workers/testLoader.worker.ts
@@ -1,4 +1,6 @@
+import { readFileSync } from 'fs'
 import { resolve } from 'path';
+import { parse } from 'jsonc-parser'
 import { TestsLoader } from 'testyts/build/lib/utils/testsLoader';
 import { TestSuiteInfo } from 'vscode-test-adapter-api';
 import { TestyConfig } from 'testyts/build/lib/interfaces/config';
@@ -15,8 +17,8 @@ catch (err) {
 
 export async function load(): Promise<TestSuiteInfo> {
     const testLoader = new TestsLoader();
-    const tsconfig = require(resolve(process.cwd(), 'tsconfig.json'));
-    const testyConfig: TestyConfig = require(resolve(process.cwd(), 'testy.json'));
+    const testyConfig: TestyConfig = parse(readFileSync(resolve(process.cwd(), 'testy.json'),{encoding:'utf8'}));
+    const tsconfig = parse(readFileSync(resolve(process.cwd(), testyConfig.tsconfig || 'tsconfig.json'),{encoding:'utf8'}));
 
     const tests = await testLoader.loadTests(process.cwd(), testyConfig.include, tsconfig);
     const testInfo = await tests.accept(new TestConverterVisitor()) as any;

--- a/src/workers/testLoader.worker.ts
+++ b/src/workers/testLoader.worker.ts
@@ -1,9 +1,7 @@
-import { readFileSync } from 'fs'
-import { resolve } from 'path';
-import { parse } from 'jsonc-parser'
+import { TestyConfig } from 'testyts/build/lib/interfaces/config';
 import { TestsLoader } from 'testyts/build/lib/utils/testsLoader';
 import { TestSuiteInfo } from 'vscode-test-adapter-api';
-import { TestyConfig } from 'testyts/build/lib/interfaces/config';
+import { loadTestyTsConfig, loadTsConfig } from './configLoader';
 import { TestConverterVisitor } from './testConverter.visitor';
 
 try {
@@ -17,10 +15,12 @@ catch (err) {
 
 export async function load(): Promise<TestSuiteInfo> {
     const testLoader = new TestsLoader();
-    const testyConfig: TestyConfig = parse(readFileSync(resolve(process.cwd(), 'testy.json'),{encoding:'utf8'}));
-    const tsconfig = parse(readFileSync(resolve(process.cwd(), testyConfig.tsconfig || 'tsconfig.json'),{encoding:'utf8'}));
+    const testyConfig: TestyConfig = loadTestyTsConfig();
+    const tsConfig = loadTsConfig();
 
-    const tests = await testLoader.loadTests(process.cwd(), testyConfig.include, tsconfig);
+    const tests = await testLoader.loadTests(process.cwd(), testyConfig.include, tsConfig);
     const testInfo = await tests.accept(new TestConverterVisitor()) as any;
     return testInfo;
 }
+
+

--- a/src/workers/testRunner.worker.ts
+++ b/src/workers/testRunner.worker.ts
@@ -1,14 +1,12 @@
-import { TestsLoader } from 'testyts/build/lib/utils/testsLoader';
-import { readFileSync } from 'fs'
-import { resolve } from 'path';
-import { parse } from 'jsonc-parser'
 import { TestyConfig } from 'testyts/build/lib/interfaces/config';
-import { TestRunStartedEvent } from 'vscode-test-adapter-api';
-import { TestFinderVisitor } from './testFinder.visitor';
-import { TestRunnerVisitor } from 'testyts/build/lib/tests/visitors/testRunnerVisitor';
-import { ProcessMessageTestReporterDecorator } from './processMessageTestReporterDecorator';
-import { TestVisitor } from 'testyts/build/lib/tests/visitors/testVisitor';
 import { Report } from 'testyts/build/lib/reporting/report/report';
+import { TestRunnerVisitor } from 'testyts/build/lib/tests/visitors/testRunnerVisitor';
+import { TestVisitor } from 'testyts/build/lib/tests/visitors/testVisitor';
+import { TestsLoader } from 'testyts/build/lib/utils/testsLoader';
+import { TestRunStartedEvent } from 'vscode-test-adapter-api';
+import { loadTestyTsConfig, loadTsConfig } from './configLoader';
+import { ProcessMessageTestReporterDecorator } from './processMessageTestReporterDecorator';
+import { TestFinderVisitor } from './testFinder.visitor';
 
 try {
     run(JSON.parse(process.argv[process.argv.length - 1]))
@@ -20,11 +18,10 @@ catch (err) {
 
 export async function run(testsIds: string[]): Promise<void> {
     const testLoader = new TestsLoader();
-
-    const testyConfig: TestyConfig = parse(readFileSync(resolve(process.cwd(), 'testy.json'),{encoding:'utf8'}));
-    const tsconfig = parse(readFileSync(resolve(process.cwd(), testyConfig.tsconfig || 'tsconfig.json'),{encoding:'utf8'}));
-
-    const tests = await testLoader.loadTests(process.cwd(), testyConfig.include, tsconfig);
+    const testyConfig: TestyConfig = loadTestyTsConfig();
+    const tsConfig = loadTsConfig();
+    
+    const tests = await testLoader.loadTests(process.cwd(), testyConfig.include, tsConfig);
     testsIds = await tests.accept(new TestFinderVisitor(testsIds));
     process.send(<TestRunStartedEvent>{ type: 'started', tests: testsIds });
 


### PR DESCRIPTION
Summary:
-Update [testyts](https://github.com/Testy/TestyTs) dependency
-Allow comments in tsconfig (via [jsonc-parser](https://github.com/microsoft/node-jsonc-parser))
-Show user error message if load fails
-Fix align in README
-Add tsc task to launch (so you don't need to run tsc manually every time you debug)

Now it will show error if load fails because of tsc error or bad config file:
![image](https://user-images.githubusercontent.com/10637549/83318716-86918f80-a1f4-11ea-88dd-7fca914f5f1f.png)

Let me know if there are any changes you want me to make